### PR TITLE
Fix accessibility issues

### DIFF
--- a/themes/catppuccin-frappe.colorscheme
+++ b/themes/catppuccin-frappe.colorscheme
@@ -8,7 +8,7 @@ Color=48,52,70
 Color=48,52,70
 
 [Color0]
-Color=115,121,148
+Color=48,52,70
 
 [Color0Faint]
 Color=115,121,148
@@ -44,7 +44,7 @@ Color=229,200,144
 Color=229,200,144
 
 [Color4]
-Color=140,170,238
+Color=48,52,70
 
 [Color4Faint]
 Color=140,170,238
@@ -89,8 +89,12 @@ Color=198,208,245
 Color=198,208,245
 
 [General]
+Anchor=0.5,0.5
 Blur=false
 ColorRandomization=false
 Description=Catppuccin Frappé
+FillStyle=Tile
 Opacity=1
 Wallpaper=
+WallpaperFlipType=NoFlip
+WallpaperOpacity=1

--- a/themes/catppuccin-latte.colorscheme
+++ b/themes/catppuccin-latte.colorscheme
@@ -26,7 +26,7 @@ Color=210,15,57
 Color=210,15,57
 
 [Color2]
-Color=64,160,43
+Color=192,194,197
 
 [Color2Faint]
 Color=64,160,43
@@ -89,8 +89,12 @@ Color=76,79,105
 Color=76,79,105
 
 [General]
+Anchor=0.5,0.5
 Blur=false
 ColorRandomization=false
 Description=Catppuccin Latte
+FillStyle=Tile
 Opacity=1
 Wallpaper=
+WallpaperFlipType=NoFlip
+WallpaperOpacity=1

--- a/themes/catppuccin-macchiato.colorscheme
+++ b/themes/catppuccin-macchiato.colorscheme
@@ -8,7 +8,7 @@ Color=36,39,58
 Color=36,39,58
 
 [Color0]
-Color=110,115,141
+Color=36,39,58
 
 [Color0Faint]
 Color=110,115,141
@@ -44,7 +44,7 @@ Color=238,212,159
 Color=238,212,159
 
 [Color4]
-Color=138,173,244
+Color=40,40,51
 
 [Color4Faint]
 Color=138,173,244
@@ -89,8 +89,12 @@ Color=202,211,245
 Color=202,211,245
 
 [General]
+Anchor=0.5,0.5
 Blur=false
 ColorRandomization=false
 Description=Catppuccin Macchiato
+FillStyle=Tile
 Opacity=1
 Wallpaper=
+WallpaperFlipType=NoFlip
+WallpaperOpacity=1

--- a/themes/catppuccin-mocha.colorscheme
+++ b/themes/catppuccin-mocha.colorscheme
@@ -1,14 +1,20 @@
 [Background]
 Color=30,30,46
+RandomHueRange=360
+RandomSaturationRange=100
 
 [BackgroundFaint]
 Color=30,30,46
+RandomHueRange=360
+RandomSaturationRange=100
 
 [BackgroundIntense]
 Color=30,30,46
+RandomHueRange=360
+RandomSaturationRange=100
 
 [Color0]
-Color=108,112,134
+Color=40,40,51
 
 [Color0Faint]
 Color=108,112,134
@@ -44,7 +50,7 @@ Color=249,226,175
 Color=249,226,175
 
 [Color4]
-Color=137,180,250
+Color=40,40,51
 
 [Color4Faint]
 Color=137,180,250
@@ -81,16 +87,26 @@ Color=205,214,244
 
 [Foreground]
 Color=205,214,244
+RandomHueRange=360
+RandomSaturationRange=100
 
 [ForegroundFaint]
 Color=205,214,244
+RandomHueRange=360
+RandomSaturationRange=100
 
 [ForegroundIntense]
 Color=205,214,244
+RandomHueRange=360
+RandomSaturationRange=100
 
 [General]
+Anchor=0.5,0.5
 Blur=false
 ColorRandomization=false
 Description=Catppuccin Mocha
+FillStyle=Tile
 Opacity=1
 Wallpaper=
+WallpaperFlipType=NoFlip
+WallpaperOpacity=1


### PR DESCRIPTION
In Konsole terminal, colors 1 and 5 need adjustments for better readability, particularly when using diff tools or listing directories with folders. These changes improve text readability while preserving the theme's palette.

The issue with Konsole is that certain colors are matched against each other, not just against the foreground and background. While your theme appears sound from a design perspective - with colors matched only against foreground and background for accessibility - Konsole's poor design violates ANSI color principles by matching colors 3 and 5 against each other in certain cases. Fixing this would likely cause other issues where color 5 is matched against the background for example. However, this case where color 5 is matched against the background is far less common compared to the case where color 5 is matched against color 3.

Since Konsole themes are inherently flawed and cannot be fully accessible by design, the best approach is to optimize for common use cases. This means addressing colors 1 and 5 while maximizing compatible foreground/background combinations. While this won't create a perfect theme - which is impossible given Konsole's current design - users can adjust their themes based on their terminal usage. For my needs, readable folders, paths, and major system commands are essential.

(correct me if I am wrong, and please make any changes you feel are right).

Update: I researched the topic and found that users can modify the "LS_COLORS" on their Linux systems and turn off these weird combinations like color 3 and color 5 in our example above. In my case, I needed to append to my ZSH config file the following: `export LS_COLORS="ow=34;1:st=34;1:tw=34;1:di=34;1"`. That would resolve the issue that I was having. However, I couldn't find a clean solution that does not involve adding custom rules or modify the theme itself to fix these issues.